### PR TITLE
cbddlp: AntiAlias is valid for all numbers from 1..16

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ The command line tool is designed to be used in a 'pipeline' style, for example:
     
     Options for '.cbddlp':
     
-      -a, --anti-alias int   Override antialias level (1,2,4,8,16) (default 1)
+      -a, --anti-alias int   Override antialias level (1..16) (default 1)
       -v, --version int      Override header Version (default 2)
     
     Options for '.ctb':
@@ -126,7 +126,7 @@ The command line tool is designed to be used in a 'pipeline' style, for example:
     
     Options for '.photon':
     
-      -a, --anti-alias int   Override antialias level (1,2,4,8,16) (default 1)
+      -a, --anti-alias int   Override antialias level (1..16) (default 1)
       -v, --version int      Override header Version (default 1)
     
     Options for '.phz':

--- a/cbddlp/format.go
+++ b/cbddlp/format.go
@@ -141,7 +141,7 @@ func NewCbddlpFormatter(suffix string) (cf *CbddlpFormatter) {
 	}
 
 	cf.IntVarP(&cf.Version, "version", "v", version, "Override header Version")
-	cf.IntVarP(&cf.AntiAlias, "anti-alias", "a", antialias, "Override antialias level (1,2,4,8,16)")
+	cf.IntVarP(&cf.AntiAlias, "anti-alias", "a", antialias, "Override antialias level (1..16)")
 
 	return
 }
@@ -155,16 +155,8 @@ func (cf *CbddlpFormatter) Encode(writer uv3dp.Writer, p uv3dp.Printable) (err e
 			return
 		}
 	case 2:
-		bad := true
-		for n := 0; n < 5; n++ {
-			if cf.AntiAlias == (1 << n) {
-				bad = false
-				break
-			}
-		}
-
-		if bad {
-			err = fmt.Errorf("illegal --anti-alias setting: %v (must be one a power of 2 from 1..16)", cf.AntiAlias)
+		if cf.AntiAlias < 1 || cf.AntiAlias > 16 {
+			err = fmt.Errorf("illegal --anti-alias setting: %v (must be from 1..16)", cf.AntiAlias)
 			return
 		}
 	default:


### PR DESCRIPTION
Summary:
- Fixes #83