### PR TITLE
Fixed a rounding issue when not changing resolution

### DIFF
--- a/cmd/uv3dp/bed.go
+++ b/cmd/uv3dp/bed.go
@@ -6,11 +6,13 @@ package main
 
 import (
 	"fmt"
+	"math"
+
+	"image"
+	"image/color"
 
 	"github.com/spf13/pflag"
 	"golang.org/x/image/draw"
-	"image"
-	"image/color"
 
 	"github.com/ezrec/uv3dp"
 )
@@ -83,8 +85,8 @@ func (bc *BedCommand) Filter(input uv3dp.Printable) (output uv3dp.Printable, err
 
 	// Compute desitination rectange
 
-	// First, get the size of the src bed, scaled to the size in dest pixels
-	dstRect := image.Rect(0, 0, int(srcSize.Millimeter.X/dstXPpm), int(srcSize.Millimeter.Y/dstYPpm))
+	// First, get the size of the src bed,sscaled to the size in dest pixels
+	dstRect := image.Rect(0, 0, int(math.Round(float64(srcSize.Millimeter.X/dstXPpm))), int(math.Round(float64(srcSize.Millimeter.Y/dstYPpm))))
 
 	// Center on bed
 	dstRect = dstRect.Add(image.Point{


### PR DESCRIPTION
This fixes a rounding error in the calculation of the destination box within the transform when coordinates do not change