### PR TITLE
fixed reading error of pw0 files

### DIFF
--- a/pws/format.go
+++ b/pws/format.go
@@ -129,12 +129,12 @@ const (
 	defaultPreviewWidth  = 224
 	defaultPreviewHeight = 168
 )
-
 type Preview struct {
 	Width      uint32 // Image width
 	Resolution uint32
 	Height     uint32 // Image height
-
+	_          [4]uint32
+	
 	// little-endian 16bit colors, RGB 565 encoded.
 	imageData []byte
 }

--- a/pws/format.go
+++ b/pws/format.go
@@ -129,6 +129,7 @@ const (
 	defaultPreviewWidth  = 224
 	defaultPreviewHeight = 168
 )
+
 type Preview struct {
 	Width      uint32 // Image width
 	Resolution uint32


### PR DESCRIPTION
Hi,
I got the following error message: "panic: preview image 224x168: Expected 75264 bytes of image, got 75280"
File was created with Anycubic Photon Workshop V2.1.24.
Now the uv3dp info command is showing the right information of pw0 files for Anycubic Photon Zero.

```
Layers: 201, 480x854 slices, 55.44 x 98.64 x 10.05 mm bed required
Total time: 36m27s (32m0s exposure, 4m27s motion)
Exposure: 8s on, 1s off
Bottom: 60s on, 1s off (6 layers)
Lift: 6 mm, 180 mm/min
Retract: 0 mm, 180 mm/min
```