### PR TITLE
ctb: Fix bug where missing preview images would corrupt bottom lift height & speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,10 +205,3 @@ The command line tool is designed to be used in a 'pipeline' style, for example:
     
     Known resins: (from local user ChiTuBox config)
     
-        Profile                                  bottom 5 layers, 50; nominal 15
-        Voxelab Black for 0.05mm                 bottom 6 layers, 50; nominal 10
-        Voxelab Green for 0.05mm                 bottom 6 layers, 50; nominal 10
-        Voxelab Grey for 0.05mm                  bottom 6 layers, 50; nominal 8
-        Voxelab Red for 0.05mm                   bottom 6 layers, 50; nominal 10
-        Voxelab Transparent for 0.05mm           bottom 6 layers, 50; nominal 10
-        Voxelab White for 0.05mm                 bottom 6 layers, 50; nominal 9

--- a/cmd/uv3dp/info.go
+++ b/cmd/uv3dp/info.go
@@ -37,7 +37,22 @@ func NewInfoCommand() (info *InfoCommand) {
 	return
 }
 
+func printExposure(mode string, exp *uv3dp.Exposure) {
+	fmt.Printf("%v:\n", mode)
+	fmt.Printf("  Exposure: %.2gs on, %.2gs off", exp.LightOnTime, exp.LightOffTime)
+	if exp.LightPWM != 255 {
+		fmt.Printf(", PWM %v", exp.LightPWM)
+	}
+	fmt.Printf("  Lift: %v mm, %v mm/min\n",
+		exp.LiftHeight, exp.LiftSpeed)
+	fmt.Printf("  Retract: %v mm, %v mm/min\n",
+		exp.RetractHeight, exp.RetractSpeed)
+}
+
 func (info *InfoCommand) Filter(input uv3dp.Printable) (output uv3dp.Printable, err error) {
+	exp := input.Exposure()
+	bot := input.Bottom()
+
 	if info.SizeSummary {
 		size := input.Size()
 		fmt.Printf("Layers: %v, %vx%v slices, %.2f x %.2f x %.2f mm bed required\n",
@@ -55,27 +70,8 @@ func (info *InfoCommand) Filter(input uv3dp.Printable) (output uv3dp.Printable, 
 	}
 
 	if info.ExposureSummary {
-		exp := input.Exposure()
-		bot := input.Bottom()
-
-		fmt.Printf("Exposure: %.2gs on, %.2gs off",
-			exp.LightOnTime,
-			exp.LightOffTime)
-		if exp.LightPWM != 255 {
-			fmt.Printf(", PWM %v", exp.LightPWM)
-		}
-		fmt.Println()
-		fmt.Printf("Bottom: %.2gs on, %.2gs off",
-			bot.Exposure.LightOnTime,
-			bot.Exposure.LightOffTime)
-		if bot.Exposure.LightPWM != 255 {
-			fmt.Printf(", PWM %v", bot.Exposure.LightPWM)
-		}
-		fmt.Printf(" (%v layers)\n", bot.Count)
-		fmt.Printf("Lift: %v mm, %v mm/min\n",
-			exp.LiftHeight, exp.LiftSpeed)
-		fmt.Printf("Retract: %v mm, %v mm/min\n",
-			exp.RetractHeight, exp.RetractSpeed)
+		printExposure(fmt.Sprintf("Bottom (%v layers)", bot.Count), &bot.Exposure)
+		printExposure("Normal", &exp)
 
 		keys := input.MetadataKeys()
 


### PR DESCRIPTION
In the CTB Encode, if a preview image was missing, when writing a Version 3 the Param table that held the Bottom Lift Height & Speed would be corrupted